### PR TITLE
Improve events by tag query efficiency.

### DIFF
--- a/core/src/main/scala/akka/persistence/postgres/query/dao/ByteArrayReadJournalDao.scala
+++ b/core/src/main/scala/akka/persistence/postgres/query/dao/ByteArrayReadJournalDao.scala
@@ -20,7 +20,7 @@ import slick.jdbc.JdbcBackend._
 
 import scala.collection.immutable._
 import scala.concurrent.{ ExecutionContext, Future }
-import scala.util.{ Failure, Success, Try }
+import scala.util.Try
 
 trait BaseByteArrayReadJournalDao extends ReadJournalDao with BaseJournalDaoWithReadMessages {
   def db: Database
@@ -40,8 +40,7 @@ trait BaseByteArrayReadJournalDao extends ReadJournalDao with BaseJournalDaoWith
       maxOffset: Long,
       max: Long): Source[Try[(PersistentRepr, Long)], NotUsed] = {
     val publisher: Int => DatabasePublisher[JournalRow] = tagId =>
-      db.stream(queries.eventsByTag(List(tagId), offset, maxOffset, max).result)
-    // applies workaround for https://github.com/akka/akka-persistence-jdbc/issues/168
+      db.stream(queries.eventsByTag(List(tagId), offset, maxOffset).result)
     Source
       .future(tagIdResolver.lookupIdFor(tag))
       .flatMapConcat(_.fold(Source.empty[JournalRow])(tagId => Source.fromPublisher(publisher(tagId))))

--- a/core/src/main/scala/akka/persistence/postgres/query/dao/ReadJournalQueries.scala
+++ b/core/src/main/scala/akka/persistence/postgres/query/dao/ReadJournalQueries.scala
@@ -40,13 +40,11 @@ class ReadJournalQueries(val readJournalConfig: ReadJournalConfig) {
   protected def _eventsByTag(
       tag: Rep[List[Int]],
       offset: ConstColumn[Long],
-      maxOffset: ConstColumn[Long],
-      max: ConstColumn[Long]) = {
+      maxOffset: ConstColumn[Long]): Query[JournalTable, JournalRow, Seq] = {
     baseTableQuery()
       .filter(_.tags @> tag)
       .sortBy(_.ordering.asc)
       .filter(row => row.ordering > offset && row.ordering <= maxOffset)
-      .take(max)
   }
 
   val eventsByTag = Compiled(_eventsByTag _)

--- a/core/src/test/scala/akka/persistence/postgres/query/JournalSequenceActorTest.scala
+++ b/core/src/test/scala/akka/persistence/postgres/query/JournalSequenceActorTest.scala
@@ -7,22 +7,22 @@ package akka.persistence.postgres.query
 
 import java.util.concurrent.atomic.AtomicLong
 
-import akka.actor.{ActorRef, ActorSystem}
+import akka.actor.{ ActorRef, ActorSystem }
 import akka.pattern.ask
 import akka.persistence.postgres.config.JournalSequenceRetrievalConfig
 import akka.persistence.postgres.db.ExtendedPostgresProfile
-import akka.persistence.postgres.query.JournalSequenceActor.{GetMaxOrderingId, MaxOrderingId}
-import akka.persistence.postgres.query.dao.{ByteArrayReadJournalDao, TestProbeReadJournalDao}
-import akka.persistence.postgres.tag.{CachedTagIdResolver, SimpleTagDao}
-import akka.persistence.postgres.util.Schema.{NestedPartitions, Partitioned, Plain, SchemaType}
-import akka.persistence.postgres.{JournalRow, SharedActorSystemTestSpec}
+import akka.persistence.postgres.query.JournalSequenceActor.{ GetMaxOrderingId, MaxOrderingId }
+import akka.persistence.postgres.query.dao.{ ByteArrayReadJournalDao, TestProbeReadJournalDao }
+import akka.persistence.postgres.tag.{ CachedTagIdResolver, SimpleTagDao }
+import akka.persistence.postgres.util.Schema.{ NestedPartitions, Partitioned, Plain, SchemaType }
+import akka.persistence.postgres.{ JournalRow, SharedActorSystemTestSpec }
 import akka.serialization.SerializationExtension
-import akka.stream.scaladsl.{Sink, Source}
-import akka.stream.{Materializer, SystemMaterializer}
+import akka.stream.scaladsl.{ Sink, Source }
+import akka.stream.{ Materializer, SystemMaterializer }
 import akka.testkit.TestProbe
 import org.scalatest.time.Span
 import org.slf4j.LoggerFactory
-import slick.jdbc.{JdbcBackend, JdbcCapabilities}
+import slick.jdbc.{ JdbcBackend, JdbcCapabilities }
 
 import scala.concurrent.Future
 import scala.concurrent.duration._
@@ -30,12 +30,12 @@ import scala.concurrent.duration._
 abstract class JournalSequenceActorTest(val schemaType: SchemaType) extends QueryTestSpec(schemaType.configName) {
   private val log = LoggerFactory.getLogger(classOf[JournalSequenceActorTest])
 
-  val journalSequenceActorConfig = readJournalConfig.journalSequenceRetrievalConfiguration
-  val journalTable = schemaType.table(journalConfig.journalTableConfiguration)
+  private val journalSequenceActorConfig = readJournalConfig.journalSequenceRetrievalConfiguration
+  private val journalTable = schemaType.table(journalConfig.journalTableConfiguration)
 
   import akka.persistence.postgres.db.ExtendedPostgresProfile.api._
 
-  implicit val askTimeout = 50.millis
+  implicit val askTimeout: FiniteDuration = 50.millis
 
   private val orderingSeq = new AtomicLong(0L)
   def generateId: Long = orderingSeq.incrementAndGet()
@@ -192,7 +192,7 @@ class MockDaoJournalSequenceActorTest extends SharedActorSystemTestSpec {
 
     val almostQueryDelay = queryDelay - 50.millis
     val almostImmediately = 50.millis
-    withTestProbeJournalSequenceActor(batchSize, maxTries, queryDelay) { (daoProbe, actor) =>
+    withTestProbeJournalSequenceActor(batchSize, maxTries, queryDelay) { (daoProbe, _) =>
       daoProbe.expectMsg(almostImmediately, TestProbeReadJournalDao.JournalSequence(0, batchSize))
       val firstBatch = (1L to 40L) ++ (51L to 110L)
       daoProbe.reply(firstBatch)

--- a/core/src/test/scala/akka/persistence/postgres/query/dao/ReadJournalQueriesTest.scala
+++ b/core/src/test/scala/akka/persistence/postgres/query/dao/ReadJournalQueriesTest.scala
@@ -13,7 +13,7 @@ class ReadJournalQueriesTest extends BaseQueryTest {
   }
 
   it should "create SQL query for eventsByTag" in withReadJournalQueries { queries =>
-    queries.eventsByTag(List(11), 23L, 2L, 3L) shouldBeSQL """select "ordering", "deleted", "persistence_id", "sequence_number", "message", "tags" from "journal" where ("tags" @> ?) and (("ordering" > ?) and ("ordering" <= ?)) order by "ordering" limit ?"""
+    queries.eventsByTag(List(11), 23L, 25L) shouldBeSQL """select "ordering", "deleted", "persistence_id", "sequence_number", "message", "tags" from "journal" where ("tags" @> ?) and (("ordering" > ?) and ("ordering" <= ?)) order by "ordering""""
   }
 
   it should "create SQL query for journalSequenceQuery" in withReadJournalQueries { queries =>


### PR DESCRIPTION
Instead of querying for all events with offset larger than the passed one and then taking only the first N rows (where N == batchSize) using LIMIT clause we will query for events with an ordering value between a given range.

This small change should save some load on the DB (especially when you do not specify the offset, i.e. you search the journal from the beginning).

Also query planner is now able to prepare a better execution plan, since both, lower and upper ranges are available in the WHERE clause. In case of Partitioned schema (the one that uses ordering ranges as a partition key) it's possible to gain more benefits from partition pruning - query planner will skip all the partitions with ordering values out of the query criteria bounds.