### PR TITLE
Eliminate nasty warnings being logged by CachedTagIdResolver

### DIFF
--- a/core/src/main/scala/akka/persistence/postgres/tag/TagIdResolver.scala
+++ b/core/src/main/scala/akka/persistence/postgres/tag/TagIdResolver.scala
@@ -3,7 +3,6 @@ package akka.persistence.postgres.tag
 import akka.persistence.postgres.config.TagsConfig
 import com.github.blemale.scaffeine.{ AsyncLoadingCache, Scaffeine }
 
-import scala.concurrent.duration._
 import scala.concurrent.{ ExecutionContext, Future }
 
 trait TagIdResolver {
@@ -13,10 +12,15 @@ trait TagIdResolver {
 
 class CachedTagIdResolver(dao: TagDao, config: TagsConfig)(implicit ctx: ExecutionContext) extends TagIdResolver {
 
+  import akka.persistence.postgres.tag.CachedTagIdResolver.LookupResult
+  import LookupResult._
+
   // TODO add support for loading many tags at once
   // Package private - for testing purposes
-  private[tag] val cache: AsyncLoadingCache[String, Int] =
-    Scaffeine().expireAfterAccess(config.cacheTtl).buildAsyncFuture(findOrInsert(_, config.insertionRetryAttempts))
+  private[tag] val cache: AsyncLoadingCache[String, LookupResult] =
+    Scaffeine()
+      .expireAfterAccess(config.cacheTtl)
+      .buildAsyncFuture(findOrInsert(_, config.insertionRetryAttempts).map(Present))
 
   private def findOrInsert(tagName: String, retryAttempts: Int): Future[Int] =
     dao.find(tagName).flatMap {
@@ -28,10 +32,31 @@ class CachedTagIdResolver(dao: TagDao, config: TagsConfig)(implicit ctx: Executi
     }
 
   override def getOrAssignIdsFor(tags: Set[String]): Future[Map[String, Int]] =
-    cache.getAll(tags)
+    cache
+      .getAll(tags)
+      .map(_.map {
+        case (tagName, Present(tagId)) => (tagName, tagId)
+        case (_, NotFound)             => throw new IllegalStateException("Ooops! This should never happen.")
+      })
 
   override def lookupIdFor(tagName: String): Future[Option[Int]] =
-    cache.getFuture(tagName, dao.find(_).map(_.get)).map(Some(_)).recover {
-      case _: NoSuchElementException => None
+    Future.sequence(cache.getIfPresent(tagName).toList).map(_.headOption).flatMap {
+      case Some(Present(tagId)) => Future.successful(Some(tagId))
+      case _ =>
+        val findRes = dao.find(tagName)
+        cache.put(tagName, findRes.map(_.fold[LookupResult](NotFound)(Present)))
+        findRes
     }
+}
+
+private[tag] object CachedTagIdResolver {
+  // This (internal) ADT was introduced to avoid confusion with nested `Option`s and make the code more readable
+  sealed trait LookupResult
+  object LookupResult {
+
+    case object NotFound extends LookupResult
+
+    case class Present(tagId: Int) extends LookupResult
+
+  }
 }

--- a/core/src/test/scala/akka/persistence/postgres/tag/CachedTagIdResolverSpec.scala
+++ b/core/src/test/scala/akka/persistence/postgres/tag/CachedTagIdResolverSpec.scala
@@ -4,7 +4,6 @@ import java.util.concurrent.ThreadLocalRandom
 import java.util.concurrent.atomic.{ AtomicBoolean, AtomicLong }
 
 import akka.persistence.postgres.config.TagsConfig
-import akka.persistence.postgres.tag.CachedTagIdResolver.LookupResult._
 import com.typesafe.config.ConfigFactory
 import org.scalatest.concurrent.{ IntegrationPatience, ScalaFutures }
 import org.scalatest.matchers.should.Matchers
@@ -137,7 +136,7 @@ class CachedTagIdResolverSpec
           findF = _ => fail("Unwanted interaction with DAO (find)"),
           insertF = _ => fail("Unwanted interaction with DAO (insert)"))
         val resolver = new CachedTagIdResolver(dao, config)
-        resolver.cache.synchronous().put(fakeTagName, Present(fakeTagId))
+        resolver.cache.synchronous().put(fakeTagName, fakeTagId)
 
         // when
         val returnedTagIds = resolver.getOrAssignIdsFor(Set(fakeTagName)).futureValue
@@ -192,7 +191,7 @@ class CachedTagIdResolverSpec
           findF = _ => fail("Unwanted interaction with DAO (find)"),
           insertF = _ => fail("Unwanted interaction with DAO (insert)"))
         val resolver = new CachedTagIdResolver(dao, config)
-        resolver.cache.synchronous().put(fakeTagName, Present(fakeTagId))
+        resolver.cache.synchronous().put(fakeTagName, fakeTagId)
 
         // when
         val returnedTagId = resolver.lookupIdFor(fakeTagName).futureValue
@@ -235,9 +234,9 @@ class CachedTagIdResolverSpec
         // when
         resolver.cache.synchronous().getIfPresent(fakeTagName) should not be defined
         resolver.lookupIdFor(fakeTagName).futureValue should not be defined
-        resolver.cache.synchronous().getIfPresent(fakeTagName).value shouldBe NotFound
+        resolver.cache.synchronous().getIfPresent(fakeTagName) should not be defined
         resolver.lookupIdFor(fakeTagName).futureValue.value should equal(fakeTagId)
-        resolver.cache.synchronous().getIfPresent(fakeTagName).value should equal(Present(fakeTagId))
+        resolver.cache.synchronous().getIfPresent(fakeTagName).value should equal(fakeTagId)
       }
 
       "update cache" in {
@@ -252,7 +251,7 @@ class CachedTagIdResolverSpec
         // then
         resolver.cache.synchronous().getIfPresent(fakeTagName) should not be defined
         resolver.lookupIdFor(fakeTagName).futureValue.value should equal(fakeTagId)
-        resolver.cache.synchronous().getIfPresent(fakeTagName).value should equal(Present(fakeTagId))
+        resolver.cache.synchronous().getIfPresent(fakeTagName).value should equal(fakeTagId)
         resolver.lookupIdFor(fakeTagName).futureValue.value should equal(fakeTagId)
       }
 
@@ -267,7 +266,7 @@ class CachedTagIdResolverSpec
         // then
         resolver.cache.synchronous().getIfPresent(fakeTagName) should not be defined
         resolver.lookupIdFor(fakeTagName).futureValue should not be defined
-        resolver.cache.synchronous().getIfPresent(fakeTagName).value shouldBe NotFound
+        resolver.cache.synchronous().getIfPresent(fakeTagName) should not be defined
         resolver.lookupIdFor(fakeTagName).futureValue should not be defined
       }
     }

--- a/core/src/test/scala/akka/persistence/postgres/tag/CachedTagIdResolverSpec.scala
+++ b/core/src/test/scala/akka/persistence/postgres/tag/CachedTagIdResolverSpec.scala
@@ -1,9 +1,10 @@
 package akka.persistence.postgres.tag
 
 import java.util.concurrent.ThreadLocalRandom
-import java.util.concurrent.atomic.AtomicLong
+import java.util.concurrent.atomic.{ AtomicBoolean, AtomicLong }
 
 import akka.persistence.postgres.config.TagsConfig
+import akka.persistence.postgres.tag.CachedTagIdResolver.LookupResult._
 import com.typesafe.config.ConfigFactory
 import org.scalatest.concurrent.{ IntegrationPatience, ScalaFutures }
 import org.scalatest.matchers.should.Matchers
@@ -62,6 +63,34 @@ class CachedTagIdResolverSpec
         returnedTagIds should contain theSameElementsAs Map(fakeTagName -> fakeTagId)
       }
 
+      "assign ids if they do not exist" in {
+        // given
+        val (existingTagName, existingTagId) = ("existing-tag", 1)
+        val (tagName, tagId) = ("tag", 2)
+        val (anotherTagName, anotherTagId) = ("another-tag", 3)
+
+        val dao = new FakeTagDao(findF = {
+          case n if n == existingTagName => Future.successful(Some(existingTagId))
+          case _                         => Future.successful(None)
+        }, insertF = name => {
+          if (name == tagName) Future.successful(tagId)
+          else if (name == anotherTagName) Future.successful(anotherTagId)
+          else
+            fail(
+              s"Unwanted interaction with DAO (insert) for tagName = '$name' ($tagName, $anotherTagName, $existingTagName)")
+        })
+        val resolver = new CachedTagIdResolver(dao, config)
+
+        // when
+        val returnedTagIds = resolver.getOrAssignIdsFor(Set(tagName, anotherTagName, existingTagName)).futureValue
+
+        // then
+        returnedTagIds should contain theSameElementsAs Map(
+          tagName -> tagId,
+          anotherTagName -> anotherTagId,
+          existingTagName -> existingTagId)
+      }
+
       "hit the DAO only once and then read from cache" in {
         // given
         val fakeTagName = generateTagName()
@@ -108,7 +137,7 @@ class CachedTagIdResolverSpec
           findF = _ => fail("Unwanted interaction with DAO (find)"),
           insertF = _ => fail("Unwanted interaction with DAO (insert)"))
         val resolver = new CachedTagIdResolver(dao, config)
-        resolver.cache.put(fakeTagName, Future.successful(fakeTagId))
+        resolver.cache.synchronous().put(fakeTagName, Present(fakeTagId))
 
         // when
         val returnedTagIds = resolver.getOrAssignIdsFor(Set(fakeTagName)).futureValue
@@ -163,7 +192,7 @@ class CachedTagIdResolverSpec
           findF = _ => fail("Unwanted interaction with DAO (find)"),
           insertF = _ => fail("Unwanted interaction with DAO (insert)"))
         val resolver = new CachedTagIdResolver(dao, config)
-        resolver.cache.put(fakeTagName, Future.successful(fakeTagId))
+        resolver.cache.synchronous().put(fakeTagName, Present(fakeTagId))
 
         // when
         val returnedTagId = resolver.lookupIdFor(fakeTagName).futureValue
@@ -187,6 +216,30 @@ class CachedTagIdResolverSpec
         returnedTagId should not be defined
       }
 
+      "eventually discover newly inserted tag id mapping and update cache" in {
+        // given
+        val fakeTagName = generateTagName()
+        val fakeTagId = Random.nextInt()
+
+        val lookupMissHappened = new AtomicBoolean(false)
+
+        val dao = new FakeTagDao(
+          findF = name =>
+            if (name == fakeTagName && lookupMissHappened.getAndSet(true))
+              Future.successful(Some(fakeTagId))
+            else Future.successful(None),
+          insertF = _ => fail("Unwanted interaction with DAO (insert)"))
+
+        val resolver = new CachedTagIdResolver(dao, config)
+
+        // when
+        resolver.cache.synchronous().getIfPresent(fakeTagName) should not be defined
+        resolver.lookupIdFor(fakeTagName).futureValue should not be defined
+        resolver.cache.synchronous().getIfPresent(fakeTagName).value shouldBe NotFound
+        resolver.lookupIdFor(fakeTagName).futureValue.value should equal(fakeTagId)
+        resolver.cache.synchronous().getIfPresent(fakeTagName).value should equal(Present(fakeTagId))
+      }
+
       "update cache" in {
         // given
         val fakeTagName = generateTagName()
@@ -198,8 +251,9 @@ class CachedTagIdResolverSpec
 
         // then
         resolver.cache.synchronous().getIfPresent(fakeTagName) should not be defined
-        resolver.lookupIdFor(fakeTagName).futureValue
-        resolver.cache.synchronous().getIfPresent(fakeTagName).value should equal(fakeTagId)
+        resolver.lookupIdFor(fakeTagName).futureValue.value should equal(fakeTagId)
+        resolver.cache.synchronous().getIfPresent(fakeTagName).value should equal(Present(fakeTagId))
+        resolver.lookupIdFor(fakeTagName).futureValue.value should equal(fakeTagId)
       }
 
       "not update cache" in {
@@ -212,8 +266,9 @@ class CachedTagIdResolverSpec
 
         // then
         resolver.cache.synchronous().getIfPresent(fakeTagName) should not be defined
-        resolver.lookupIdFor(fakeTagName).futureValue
-        resolver.cache.synchronous().getIfPresent(fakeTagName) should not be defined
+        resolver.lookupIdFor(fakeTagName).futureValue should not be defined
+        resolver.cache.synchronous().getIfPresent(fakeTagName).value shouldBe NotFound
+        resolver.lookupIdFor(fakeTagName).futureValue should not be defined
       }
     }
   }


### PR DESCRIPTION
Whenever tag is not present in the database, resolver was throwing and swallowing an exception in order to break unwanted internal cache stale-state update circuit.
The root of the problem has been eliminated by ~introducing a simple algebraic data type which represents different DB-hit results~ replacing `cache.getFuture` call with `cache.getIfPresent` and `cache.put`.