### PR TITLE
Make journal event and snapshot metadata jsonb more compact.

### DIFF
--- a/core/src/main/scala/akka/persistence/postgres/journal/dao/ByteArrayJournalSerializer.scala
+++ b/core/src/main/scala/akka/persistence/postgres/journal/dao/ByteArrayJournalSerializer.scala
@@ -39,8 +39,8 @@ class ByteArrayJournalSerializer(serialization: Serialization, tagConverter: Tag
       val meta =
         Metadata(
           serId,
-          Option(serManifest).filterNot(_.isBlank),
-          Option(persistentRepr.manifest).filterNot(_.isBlank),
+          Option(serManifest).filterNot(_.trim.isEmpty),
+          Option(persistentRepr.manifest).filterNot(_.trim.isEmpty),
           persistentRepr.writerUuid,
           persistentRepr.timestamp)
       JournalRow(

--- a/core/src/main/scala/akka/persistence/postgres/snapshot/dao/ByteArraySnapshotSerializer.scala
+++ b/core/src/main/scala/akka/persistence/postgres/snapshot/dao/ByteArraySnapshotSerializer.scala
@@ -23,7 +23,7 @@ class ByteArraySnapshotSerializer(serialization: Serialization) extends Snapshot
       ser <- Try(serialization.findSerializerFor(payload))
       serializedSnapshot <- serialization.serialize(payload)
     } yield {
-      val metadataJson = Metadata(ser.identifier, Option(Serializers.manifestFor(ser, payload)).filterNot(_.isBlank))
+      val metadataJson = Metadata(ser.identifier, Option(Serializers.manifestFor(ser, payload)).filterNot(_.trim.isEmpty))
       SnapshotRow(
         metadata.persistenceId,
         metadata.sequenceNr,

--- a/core/src/test/scala/akka/persistence/postgres/SharedActorSystemTestSpec.scala
+++ b/core/src/test/scala/akka/persistence/postgres/SharedActorSystemTestSpec.scala
@@ -7,11 +7,11 @@ package akka.persistence.postgres
 
 import akka.actor.ActorSystem
 import akka.persistence.postgres.config.{ JournalConfig, ReadJournalConfig }
+import akka.persistence.postgres.db.SlickExtension
 import akka.persistence.postgres.query.javadsl.PostgresReadJournal
 import akka.persistence.postgres.util.DropCreate
-import akka.persistence.postgres.db.SlickExtension
 import akka.serialization.SerializationExtension
-import akka.stream.{ ActorMaterializer, Materializer }
+import akka.stream.{ Materializer, SystemMaterializer }
 import akka.util.Timeout
 import com.typesafe.config.{ Config, ConfigFactory, ConfigValue }
 import org.scalatest.BeforeAndAfterAll
@@ -26,7 +26,7 @@ abstract class SharedActorSystemTestSpec(val config: Config) extends SimpleSpec 
     })
 
   implicit lazy val system: ActorSystem = ActorSystem("test", config)
-  implicit lazy val mat: Materializer = ActorMaterializer()
+  implicit lazy val mat: Materializer = SystemMaterializer(system).materializer
 
   implicit lazy val ec: ExecutionContext = system.dispatcher
   implicit val pc: PatienceConfig = PatienceConfig(timeout = 1.minute)
@@ -40,6 +40,7 @@ abstract class SharedActorSystemTestSpec(val config: Config) extends SimpleSpec 
   val readJournalConfig = new ReadJournalConfig(config.getConfig(PostgresReadJournal.Identifier))
 
   override protected def afterAll(): Unit = {
+    super.afterAll()
     db.close()
     system.terminate().futureValue
   }

--- a/core/src/test/scala/akka/persistence/postgres/snapshot/dao/ByteArraySnapshotSerializerTest.scala
+++ b/core/src/test/scala/akka/persistence/postgres/snapshot/dao/ByteArraySnapshotSerializerTest.scala
@@ -1,0 +1,71 @@
+package akka.persistence.postgres.snapshot.dao
+
+import java.time.{ LocalDateTime, ZoneOffset }
+
+import akka.persistence.SnapshotMetadata
+import akka.persistence.postgres.SharedActorSystemTestSpec
+import akka.persistence.postgres.snapshot.dao.SnapshotTables.SnapshotRow
+import akka.serialization.Serializers
+import io.circe.Json
+import org.scalatest.TryValues
+
+class ByteArraySnapshotSerializerTest extends SharedActorSystemTestSpec with TryValues {
+
+  val serializer = new ByteArraySnapshotSerializer(serialization)
+  val fakeSnapshot = "fake snapshot"
+  val payloadSer = serialization.serializerFor(fakeSnapshot.getClass)
+  val serId = payloadSer.identifier
+  val serManifest = Serializers.manifestFor(payloadSer, fakeSnapshot)
+
+  it should "serialize snapshot and its metadata" in {
+    val timestamp = LocalDateTime.now().toEpochSecond(ZoneOffset.UTC)
+    val result = serializer.serialize(SnapshotMetadata("per-1", 42, timestamp), fakeSnapshot)
+    val row = result.get
+    row.persistenceId should equal("per-1")
+    row.sequenceNumber shouldBe 42
+    row.created shouldBe timestamp
+    row.metadata should equal {
+      Json.obj(
+        // serialization manifest for String should be blank and omitted
+        "sid" -> Json.fromInt(serId))
+    }
+  }
+
+  {
+
+    val serializedPayload = {
+      val timestamp = LocalDateTime.now().toEpochSecond(ZoneOffset.UTC)
+      val row = serializer.serialize(SnapshotMetadata("per-1", 42, timestamp), fakeSnapshot).get
+      row.snapshot
+    }
+
+    it should "deserialize snapshot and metadata" in {
+      val timestamp = LocalDateTime.now().toEpochSecond(ZoneOffset.UTC)
+      val meta = Json.obj("sid" -> Json.fromInt(serId))
+      val row = SnapshotRow("per-1", 42, timestamp, serializedPayload, meta)
+      val (metadata, snapshot) = serializer.deserialize(row).get
+      snapshot should equal(fakeSnapshot)
+      metadata should equal(SnapshotMetadata("per-1", 42, timestamp))
+    }
+
+    it should "deserialize metadata with legacy long keys" in {
+      val timestamp = LocalDateTime.now().toEpochSecond(ZoneOffset.UTC)
+      val meta = Json.obj("serId" -> Json.fromInt(serId), "serManifest" -> Json.fromString(""))
+      val row = SnapshotRow("per-1", 42, timestamp, serializedPayload, meta)
+      val (metadata, _) = serializer.deserialize(row).get
+      metadata should equal(SnapshotMetadata("per-1", 42, timestamp))
+    }
+
+    it should "deserialize metadata with mixed legacy long & new short keys - short keys takes precedence" in {
+      val timestamp = LocalDateTime.now().toEpochSecond(ZoneOffset.UTC)
+      val meta = Json.obj(
+        "sid" -> Json.fromInt(serId),
+        "serId" -> Json.fromInt(-1),
+        "serManifest" -> Json.fromString("this will be ignored"))
+      val row = SnapshotRow("per-1", 42, timestamp, serializedPayload, meta)
+      val (metadata, _) = serializer.deserialize(row).get
+      metadata should equal(SnapshotMetadata("per-1", 42, timestamp))
+    }
+  }
+
+}

--- a/migration/src/main/scala/akka/persistence/postgres/migration/v2/journal/NewJournalSerializer.scala
+++ b/migration/src/main/scala/akka/persistence/postgres/migration/v2/journal/NewJournalSerializer.scala
@@ -23,8 +23,8 @@ private[v2] class NewJournalSerializer(serialization: Serialization) {
       val meta =
         Metadata(
           serId,
-          Option(serManifest).filterNot(_.isBlank),
-          Option(persistentRepr.manifest).filterNot(_.isBlank),
+          Option(serManifest).filterNot(_.trim.isEmpty),
+          Option(persistentRepr.manifest).filterNot(_.trim.isEmpty),
           persistentRepr.writerUuid,
           persistentRepr.timestamp)
       (serializedEvent, meta.asJson)

--- a/migration/src/main/scala/akka/persistence/postgres/migration/v2/journal/NewJournalSerializer.scala
+++ b/migration/src/main/scala/akka/persistence/postgres/migration/v2/journal/NewJournalSerializer.scala
@@ -21,18 +21,30 @@ private[v2] class NewJournalSerializer(serialization: Serialization) {
       val serId = serializer.identifier
       val serManifest = Serializers.manifestFor(serializer, payload)
       val meta =
-        Metadata(serId, serManifest, persistentRepr.manifest, persistentRepr.writerUuid, persistentRepr.timestamp)
+        Metadata(
+          serId,
+          Option(serManifest).filterNot(_.isBlank),
+          Option(persistentRepr.manifest).filterNot(_.isBlank),
+          persistentRepr.writerUuid,
+          persistentRepr.timestamp)
       (serializedEvent, meta.asJson)
     }
   }
 }
 
 private object NewJournalSerializer {
-  case class Metadata(serId: Int, serManifest: String, eventManifest: String, writerUuid: String, timestamp: Long)
+  case class Metadata(
+      serId: Int,
+      serManifest: Option[String],
+      eventManifest: Option[String],
+      writerUuid: String,
+      timestamp: Long)
 
   object Metadata {
-    implicit val encoder: Encoder[Metadata] =
-      Encoder.forProduct5("serId", "serManifest", "eventManifest", "writerUuid", "timestamp")(e =>
-        (e.serId, e.serManifest, e.eventManifest, e.writerUuid, e.timestamp))
+    implicit val encoder: Encoder[Metadata] = Encoder
+      .forProduct5[Metadata, Int, Option[String], Option[String], String, Long]("sid", "sm", "em", "wid", "t") { e =>
+        (e.serId, e.serManifest, e.eventManifest, e.writerUuid, e.timestamp)
+      }
+      .mapJson(_.dropNullValues)
   }
 }

--- a/migration/src/main/scala/akka/persistence/postgres/migration/v2/snapshot/NewSnapshotSerializer.scala
+++ b/migration/src/main/scala/akka/persistence/postgres/migration/v2/snapshot/NewSnapshotSerializer.scala
@@ -16,7 +16,7 @@ private[v2] class NewSnapshotSerializer(serialization: Serialization) {
       ser <- Try(serialization.findSerializerFor(payload))
       serializedSnapshot <- serialization.serialize(payload)
     } yield {
-      val metadataJson = Metadata(ser.identifier, Serializers.manifestFor(ser, payload))
+      val metadataJson = Metadata(ser.identifier, Option(Serializers.manifestFor(ser, payload)).filterNot(_.isBlank))
       (serializedSnapshot, metadataJson.asJson)
     }
   }
@@ -24,10 +24,12 @@ private[v2] class NewSnapshotSerializer(serialization: Serialization) {
 }
 
 private object NewSnapshotSerializer {
-  case class Metadata(serId: Int, serManifest: String)
+  case class Metadata(serId: Int, serManifest: Option[String])
 
   object Metadata {
-    implicit val encoder: Encoder[Metadata] = Encoder.forProduct2("serId", "serManifest")(m => (m.serId, m.serManifest))
+    implicit val encoder: Encoder[Metadata] = Encoder
+      .forProduct2[Metadata, Int, Option[String]]("sid", "sm")(m => (m.serId, m.serManifest))
+      .mapJson(_.dropNullValues)
   }
 
 }

--- a/migration/src/main/scala/akka/persistence/postgres/migration/v2/snapshot/NewSnapshotSerializer.scala
+++ b/migration/src/main/scala/akka/persistence/postgres/migration/v2/snapshot/NewSnapshotSerializer.scala
@@ -16,7 +16,7 @@ private[v2] class NewSnapshotSerializer(serialization: Serialization) {
       ser <- Try(serialization.findSerializerFor(payload))
       serializedSnapshot <- serialization.serialize(payload)
     } yield {
-      val metadataJson = Metadata(ser.identifier, Option(Serializers.manifestFor(ser, payload)).filterNot(_.isBlank))
+      val metadataJson = Metadata(ser.identifier, Option(Serializers.manifestFor(ser, payload)).filterNot(_.trim.isEmpty))
       (serializedSnapshot, metadataJson.asJson)
     }
   }


### PR DESCRIPTION
This is done by abbreviating keys (while the previous, long keys are still supported in the decoder) and skipping blank values.