### PR TITLE
Fix a bug in eventsByTag query

### DIFF
--- a/core/src/main/scala/akka/persistence/postgres/query/scaladsl/PostgresReadJournal.scala
+++ b/core/src/main/scala/akka/persistence/postgres/query/scaladsl/PostgresReadJournal.scala
@@ -115,7 +115,8 @@ class PostgresReadJournal(config: Config, configPath: String)(implicit val syste
           knownIds += id
           xs
         }
-        id => next(id)
+        id =>
+          next(id)
       }
 
   private def adaptEvents(repr: PersistentRepr): Seq[PersistentRepr] = {
@@ -266,6 +267,10 @@ class PostgresReadJournal(config: Config, configPath: String)(implicit val syste
                    * then we should not move the query window forward. Otherwise we might miss (skip) some events.
                    * By setting nextStartingOffset to `from` we wait for either maxOrdering to be discovered or first
                    * event to be persisted in the journal. */
+                  from
+                case (Nil, maxOrdering) if maxOrdering < from =>
+                  /* In case of either `maxOrdering` is staled or journal didn't reach the offset - we should wait
+                   * for either maxOrdering to be discovered or journal to reach the requested offset */
                   from
                 case (Nil, maxOrdering) =>
                   /* If no events matched the tag between `from` and `to` (`from + batchSize`) and `maxOrdering` then


### PR DESCRIPTION
Under some circumstances `JournalSequenceActor` can return staled `MaxOrderingId`. 
When it's less than the current offset or the initial offset is grater than the maximum ordering value present in the database (for example: we have 1M events and we query for events with offset > 5M) we might experience read journal returning events older than expected.

In either case read journal should wait for either maxOrdering to be discovered or journal to reach the requested offset.

This fix prevents from reading events with ordering value less than current offset.