### PR TITLE
Add NOT NULL constraint on metadata columns

### DIFF
--- a/core/src/test/resources/schema/postgres/nested-partitions-schema.sql
+++ b/core/src/test/resources/schema/postgres/nested-partitions-schema.sql
@@ -34,7 +34,7 @@ CREATE TABLE IF NOT EXISTS public.journal
     persistence_id  TEXT                  NOT NULL,
     message         BYTEA                 NOT NULL,
     tags            int[],
-    metadata        jsonb,
+    metadata        jsonb                 NOT NULL,
     PRIMARY KEY (persistence_id, sequence_number)
 ) PARTITION BY LIST (persistence_id);
 
@@ -61,6 +61,6 @@ CREATE TABLE IF NOT EXISTS public.snapshot
     sequence_number BIGINT NOT NULL,
     created         BIGINT NOT NULL,
     snapshot        BYTEA  NOT NULL,
-    metadata        jsonb,
+    metadata        jsonb  NOT NULL,
     PRIMARY KEY (persistence_id, sequence_number)
 );

--- a/core/src/test/resources/schema/postgres/partitioned-schema.sql
+++ b/core/src/test/resources/schema/postgres/partitioned-schema.sql
@@ -34,7 +34,7 @@ CREATE TABLE IF NOT EXISTS public.journal
     persistence_id  TEXT                  NOT NULL,
     message         BYTEA                 NOT NULL,
     tags            int[],
-    metadata        jsonb,
+    metadata        jsonb                 NOT NULL,
     PRIMARY KEY (persistence_id, sequence_number, ordering)
 ) PARTITION BY RANGE (ordering);
 
@@ -42,6 +42,7 @@ CREATE SEQUENCE journal_ordering_seq OWNED BY public.journal.ordering;
 
 CREATE EXTENSION IF NOT EXISTS intarray WITH SCHEMA public;
 CREATE INDEX journal_tags_idx ON public.journal USING GIN (tags gin__int_ops);
+CREATE INDEX journal_ordering_idx ON public.journal USING BRIN (ordering);
 
 DROP TABLE IF EXISTS public.tags;
 
@@ -62,6 +63,6 @@ CREATE TABLE IF NOT EXISTS public.snapshot
     sequence_number BIGINT NOT NULL,
     created         BIGINT NOT NULL,
     snapshot        BYTEA  NOT NULL,
-    metadata        jsonb,
+    metadata        jsonb  NOT NULL,
     PRIMARY KEY (persistence_id, sequence_number)
 );

--- a/core/src/test/resources/schema/postgres/plain-schema.sql
+++ b/core/src/test/resources/schema/postgres/plain-schema.sql
@@ -8,7 +8,7 @@ CREATE TABLE IF NOT EXISTS public.journal
     persistence_id  TEXT                  NOT NULL,
     message         BYTEA                 NOT NULL,
     tags            int[],
-    metadata        jsonb,
+    metadata        jsonb                 NOT NULL,
     PRIMARY KEY (persistence_id, sequence_number)
 );
 
@@ -35,6 +35,6 @@ CREATE TABLE IF NOT EXISTS public.snapshot
     sequence_number BIGINT NOT NULL,
     created         BIGINT NOT NULL,
     snapshot        BYTEA  NOT NULL,
-    metadata        jsonb,
+    metadata        jsonb  NOT NULL,
     PRIMARY KEY (persistence_id, sequence_number)
 );


### PR DESCRIPTION
Metadata contains necessary informations for serializers and it's always present. Schema should reflect that.