### PR TITLE
Partitioned schema - change primary key.

### DIFF
--- a/core/src/test/resources/schema/postgres/partitioned-schema.sql
+++ b/core/src/test/resources/schema/postgres/partitioned-schema.sql
@@ -35,14 +35,14 @@ CREATE TABLE IF NOT EXISTS public.journal
     message         BYTEA                 NOT NULL,
     tags            int[],
     metadata        jsonb                 NOT NULL,
-    PRIMARY KEY (persistence_id, sequence_number, ordering)
+    PRIMARY KEY (ordering)
 ) PARTITION BY RANGE (ordering);
 
 CREATE SEQUENCE journal_ordering_seq OWNED BY public.journal.ordering;
 
 CREATE EXTENSION IF NOT EXISTS intarray WITH SCHEMA public;
 CREATE INDEX journal_tags_idx ON public.journal USING GIN (tags gin__int_ops);
-CREATE INDEX journal_ordering_idx ON public.journal USING BRIN (ordering);
+CREATE INDEX journal_persistence_sequence_idx ON public.journal USING BTREE (persistence_id, sequence_number);
 
 DROP TABLE IF EXISTS public.tags;
 

--- a/scripts/migration/partitioned/1-create-schema.sql
+++ b/scripts/migration/partitioned/1-create-schema.sql
@@ -14,7 +14,7 @@ BEGIN
         persistence_id  TEXT                  NOT NULL,
         message         BYTEA                 NOT NULL,
         tags            int[],
-        PRIMARY KEY (persistence_id, sequence_number, ordering)
+        PRIMARY KEY (ordering)
     ) PARTITION BY RANGE (ordering);';
 
     EXECUTE 'CREATE SEQUENCE ' || destination_journal || '_ordering_seq OWNED BY ' || destination_journal || '.ordering;';

--- a/scripts/migration/partitioned/6-create-indexes.sql
+++ b/scripts/migration/partitioned/6-create-indexes.sql
@@ -7,5 +7,6 @@ BEGIN
 
     EXECUTE 'CREATE EXTENSION IF NOT EXISTS intarray WITH SCHEMA ' || destination_schema || ';';
     EXECUTE 'CREATE INDEX ' || destination_journal_table || '_tags_idx ON ' || destination_journal || ' USING GIN (tags gin__int_ops);';
+    EXECUTE 'CREATE INDEX ' || destination_journal_table || '_persistence_sequence_idx ON ' || destination_journal || ' USING BTREE (persistence_id, sequence_number);';
 END ;
 $$ LANGUAGE plpgsql;

--- a/scripts/migration/partitioned/7-drop-migration-procedures.sql
+++ b/scripts/migration/partitioned/7-drop-migration-procedures.sql
@@ -5,4 +5,3 @@ DROP PROCEDURE IF EXISTS copy_data;
 DROP PROCEDURE IF EXISTS copy_piece_of_data;
 DROP PROCEDURE IF EXISTS move_sequence;
 DROP PROCEDURE IF EXISTS create_indexes;
-


### PR DESCRIPTION
In schema partitioned by ordering, the `ordering` column was indexed twice: by the primary key (it must include all partition keys) and a dedicated BRIN index (for fast lookup).

This PR replaces the dedicated BRIN index with a single column PK and adds auxiliary BTREE index on persistence_id and sequence_number columns.