### PR TITLE
Mark akka-persistence-query as `Provided`

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -31,6 +31,9 @@ For a maven project add:
 ```
 to your `pom.xml`.
 
+> :warning: Since Akka [does not allow mixed versions](https://doc.akka.io/docs/akka/current/common/binary-compatibility-rules.html#mixed-versioning-is-not-allowed) in a project, Akka dependencies are marked a `Provided`. This means that your application `libraryDependencies` needs to directly include Akka as a dependency. The minimal supported Akka version is 2.6.16.  
+
+
 ## Source code
 
 Source code for this plugin can be found on [GitHub](https://github.com/SwissBorg/akka-persistence-postgres).

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,8 +4,7 @@ object Dependencies {
   val Scala213 = "2.13.7"
   val ScalaVersions = Seq(Scala213)
 
-  val AkkaVersion = "2.6.18"
-  val AkkaBinaryVersion = "2.6"
+  val AkkaVersion = "2.6.16"
   val FlywayVersion = "8.2.3"
   val ScaffeineVersion = "5.1.1"
   val ScalaTestVersion = "3.2.10"
@@ -25,16 +24,17 @@ object Dependencies {
     "com.typesafe.akka" %% "akka-persistence-tck" % AkkaVersion % Test,
     "com.typesafe.akka" %% "akka-stream-testkit" % AkkaVersion % Test,
     "com.typesafe.akka" %% "akka-testkit" % AkkaVersion % Test,
-    "com.typesafe.akka" %% "akka-persistence-query" % AkkaVersion,
+    "com.typesafe.akka" %% "akka-persistence-query" % AkkaVersion % Provided,
     "com.typesafe.slick" %% "slick" % SlickVersion,
     "com.typesafe.slick" %% "slick-hikaricp" % SlickVersion,
     "org.scalatest" %% "scalatest" % ScalaTestVersion % Test) ++ JdbcDrivers.map(_ % Test)
 
-  val Migration: Seq[ModuleID] = (Seq(
-    "org.scalatest" %% "scalatest" % ScalaTestVersion,
-    "com.typesafe.akka" %% "akka-testkit" % AkkaVersion,
-    "ch.qos.logback" % "logback-classic" % LogbackVersion,
-    "com.typesafe.akka" %% "akka-slf4j" % AkkaVersion,
-    "com.typesafe.akka" %% "akka-serialization-jackson" % AkkaVersion,
-    "org.flywaydb" % "flyway-core" % FlywayVersion) ++ JdbcDrivers).map(_ % Test)
+  val Migration: Seq[ModuleID] =
+    Seq("com.typesafe.akka" %% "akka-persistence-query" % AkkaVersion).map(_ % Compile) ++ (Seq(
+      "org.scalatest" %% "scalatest" % ScalaTestVersion,
+      "com.typesafe.akka" %% "akka-testkit" % AkkaVersion,
+      "ch.qos.logback" % "logback-classic" % LogbackVersion,
+      "com.typesafe.akka" %% "akka-slf4j" % AkkaVersion,
+      "com.typesafe.akka" %% "akka-serialization-jackson" % AkkaVersion,
+      "org.flywaydb" % "flyway-core" % FlywayVersion) ++ JdbcDrivers).map(_ % Test)
 }


### PR DESCRIPTION
So that dependent projects do not need to exclude akka deps (or align versions) with something like this

```scala
"com.swissborg" %% "akka-persistence-postgres" % "0.5.0-M4" excludeAll ExclusionRule(
    organization = "com.typesafe.akka"
  )
  ```