### PR TITLE
Partition pruning: Use min_ordering only on messages query

### DIFF
--- a/core/src/main/scala/akka/persistence/postgres/journal/dao/JournalQueries.scala
+++ b/core/src/main/scala/akka/persistence/postgres/journal/dao/JournalQueries.scala
@@ -68,7 +68,7 @@ class JournalQueries(journalTable: TableQuery[JournalTable]) {
       .sortBy(_.sequenceNumber.asc)
       .take(max)
 
-  private def _messagesOrderingBoundedQuery(
+  private def _messagesMinOrderingBoundedQuery(
       persistenceId: Rep[String],
       fromSequenceNr: Rep[Long],
       toSequenceNr: Rep[Long],
@@ -85,5 +85,5 @@ class JournalQueries(journalTable: TableQuery[JournalTable]) {
 
   val messagesQuery = Compiled(_messagesQuery _)
 
-  val messagesOrderingBoundedQuery = Compiled(_messagesOrderingBoundedQuery _)
+  val messagesMinOrderingBoundedQuery = Compiled(_messagesMinOrderingBoundedQuery _)
 }

--- a/core/src/main/scala/akka/persistence/postgres/journal/dao/JournalQueries.scala
+++ b/core/src/main/scala/akka/persistence/postgres/journal/dao/JournalQueries.scala
@@ -73,15 +73,13 @@ class JournalQueries(journalTable: TableQuery[JournalTable]) {
       fromSequenceNr: Rep[Long],
       toSequenceNr: Rep[Long],
       max: ConstColumn[Long],
-      minOrdering: Rep[Long],
-      maxOrdering: Rep[Long]): Query[JournalTable, JournalRow, Seq] =
+      minOrdering: Rep[Long]): Query[JournalTable, JournalRow, Seq] =
     journalTable
       .filter(_.persistenceId === persistenceId)
       .filter(_.deleted === false)
       .filter(_.sequenceNumber >= fromSequenceNr)
       .filter(_.sequenceNumber <= toSequenceNr)
       .filter(_.ordering >= minOrdering)
-      .filter(_.ordering <= maxOrdering)
       .sortBy(_.sequenceNumber.asc)
       .take(max)
 

--- a/core/src/main/scala/akka/persistence/postgres/journal/dao/PartitionedJournalDao.scala
+++ b/core/src/main/scala/akka/persistence/postgres/journal/dao/PartitionedJournalDao.scala
@@ -1,19 +1,15 @@
 package akka.persistence.postgres.journal.dao
 
-import akka.NotUsed
-import akka.persistence.PersistentRepr
 import akka.persistence.postgres.JournalRow
 import akka.persistence.postgres.config.JournalConfig
 import akka.persistence.postgres.db.DbErrors.{ withHandledIndexErrors, withHandledPartitionErrors }
 import akka.serialization.Serialization
 import akka.stream.Materializer
-import akka.stream.scaladsl.Source
 import slick.jdbc.JdbcBackend.Database
 
 import java.util.concurrent.atomic.AtomicReference
 import scala.collection.immutable.{ Nil, Seq }
 import scala.concurrent.{ ExecutionContext, Future }
-import scala.util.Try
 
 class PartitionedJournalDao(db: Database, journalConfig: JournalConfig, serialization: Serialization)(
     implicit ec: ExecutionContext,
@@ -87,30 +83,5 @@ class PartitionedJournalDao(db: Database, journalConfig: JournalConfig, serializ
     } else {
       DBIO.successful(())
     }
-  }
-
-  override def messages(
-      persistenceId: String,
-      fromSequenceNr: Long,
-      toSequenceNr: Long,
-      max: Long): Source[Try[(PersistentRepr, Long)], NotUsed] = {
-
-    // This behaviour override is only applied here, because it is only useful on the PartitionedJournal strategy.
-    val query = if (journalConfig.useJournalMetadata) {
-      metadataQueries.minAndMaxOrderingForPersistenceId(persistenceId).result.headOption.flatMap {
-        case Some((minOrdering, maxOrdering)) =>
-          // if journal_metadata knows the min and max ordering of a persistenceId,
-          // use them to help the query planner to avoid scanning unnecessary partitions.
-          queries
-            .messagesOrderingBoundedQuery(persistenceId, fromSequenceNr, toSequenceNr, max, minOrdering, maxOrdering)
-            .result
-        case None =>
-          // fallback to standard behaviour
-          queries.messagesQuery(persistenceId, fromSequenceNr, toSequenceNr, max).result
-      }
-    } else
-      queries.messagesQuery(persistenceId, fromSequenceNr, toSequenceNr, max).result
-
-    Source.fromPublisher(db.stream(query)).via(serializer.deserializeFlow)
   }
 }

--- a/core/src/main/scala/akka/persistence/postgres/journal/dao/PartitionedJournalDao.scala
+++ b/core/src/main/scala/akka/persistence/postgres/journal/dao/PartitionedJournalDao.scala
@@ -102,7 +102,7 @@ class PartitionedJournalDao(db: Database, journalConfig: JournalConfig, serializ
           // if journal_metadata knows the min ordering of a persistenceId,
           // use it to help the query planner to avoid scanning unnecessary partitions.
           queries
-            .messagesOrderingBoundedQuery(persistenceId, fromSequenceNr, toSequenceNr, max, minOrdering)
+            .messagesMinOrderingBoundedQuery(persistenceId, fromSequenceNr, toSequenceNr, max, minOrdering)
             .result
         case None =>
           // fallback to standard behaviour

--- a/core/src/main/scala/akka/persistence/postgres/query/dao/PartitionedReadJournalDao.scala
+++ b/core/src/main/scala/akka/persistence/postgres/query/dao/PartitionedReadJournalDao.scala
@@ -1,7 +1,5 @@
 package akka.persistence.postgres.query.dao
 
-import akka.NotUsed
-import akka.persistence.PersistentRepr
 import akka.persistence.postgres.config.ReadJournalConfig
 import akka.persistence.postgres.journal.dao.{
   ByteArrayJournalSerializer,
@@ -11,11 +9,9 @@ import akka.persistence.postgres.journal.dao.{
 import akka.persistence.postgres.tag.{ CachedTagIdResolver, SimpleTagDao, TagIdResolver }
 import akka.serialization.Serialization
 import akka.stream.Materializer
-import akka.stream.scaladsl.Source
 import slick.jdbc.JdbcBackend.Database
 
 import scala.concurrent.ExecutionContext
-import scala.util.Try
 
 class PartitionedReadJournalDao(
     val db: Database,
@@ -23,8 +19,6 @@ class PartitionedReadJournalDao(
     serialization: Serialization,
     val tagIdResolver: TagIdResolver)(implicit val ec: ExecutionContext, val mat: Materializer)
     extends BaseByteArrayReadJournalDao {
-
-  import akka.persistence.postgres.db.ExtendedPostgresProfile.api._
 
   val queries = new ReadJournalQueries(
     PartitionedJournalTable(readJournalConfig.journalTableConfiguration),
@@ -37,28 +31,4 @@ class PartitionedReadJournalDao(
     new CachedTagIdResolver(
       new SimpleTagDao(db, readJournalConfig.tagsTableConfiguration),
       readJournalConfig.tagsConfig))
-
-  override def messages(
-      persistenceId: String,
-      fromSequenceNr: Long,
-      toSequenceNr: Long,
-      max: Long): Source[Try[(PersistentRepr, Long)], NotUsed] = {
-    // This behaviour override is only applied here, because it is only useful on the PartitionedJournal strategy.
-    val query = if (readJournalConfig.useJournalMetadata) {
-      metadataQueries.minAndMaxOrderingForPersistenceId(persistenceId).result.headOption.flatMap {
-        case Some((minOrdering, maxOrdering)) =>
-          // if journal_metadata knows the min and max ordering of a persistenceId,
-          // use them to help the query planner to avoid scanning unnecessary partitions.
-          queries
-            .messagesOrderingBoundedQuery(persistenceId, fromSequenceNr, toSequenceNr, max, minOrdering, maxOrdering)
-            .result
-        case None =>
-          // fallback to standard behaviour
-          queries.messagesQuery(persistenceId, fromSequenceNr, toSequenceNr, max).result
-      }
-    } else
-      queries.messagesQuery(persistenceId, fromSequenceNr, toSequenceNr, max).result
-
-    Source.fromPublisher(db.stream(query)).via(serializer.deserializeFlow)
-  }
 }

--- a/core/src/main/scala/akka/persistence/postgres/query/dao/PartitionedReadJournalDao.scala
+++ b/core/src/main/scala/akka/persistence/postgres/query/dao/PartitionedReadJournalDao.scala
@@ -49,7 +49,7 @@ class PartitionedReadJournalDao(
         case Some((minOrdering, _)) =>
           // if journal_metadata knows the min ordering of a persistenceId,
           // use it to help the query planner to avoid scanning unnecessary partitions.
-          queries.messagesOrderingBoundedQuery(persistenceId, fromSequenceNr, toSequenceNr, max, minOrdering).result
+          queries.messagesMinOrderingBoundedQuery(persistenceId, fromSequenceNr, toSequenceNr, max, minOrdering).result
         case None =>
           // fallback to standard behaviour
           queries.messagesQuery(persistenceId, fromSequenceNr, toSequenceNr, max).result

--- a/core/src/main/scala/akka/persistence/postgres/query/dao/PartitionedReadJournalDao.scala
+++ b/core/src/main/scala/akka/persistence/postgres/query/dao/PartitionedReadJournalDao.scala
@@ -1,5 +1,7 @@
 package akka.persistence.postgres.query.dao
 
+import akka.NotUsed
+import akka.persistence.PersistentRepr
 import akka.persistence.postgres.config.ReadJournalConfig
 import akka.persistence.postgres.journal.dao.{
   ByteArrayJournalSerializer,
@@ -9,9 +11,11 @@ import akka.persistence.postgres.journal.dao.{
 import akka.persistence.postgres.tag.{ CachedTagIdResolver, SimpleTagDao, TagIdResolver }
 import akka.serialization.Serialization
 import akka.stream.Materializer
+import akka.stream.scaladsl.Source
 import slick.jdbc.JdbcBackend.Database
 
 import scala.concurrent.ExecutionContext
+import scala.util.Try
 
 class PartitionedReadJournalDao(
     val db: Database,
@@ -19,6 +23,8 @@ class PartitionedReadJournalDao(
     serialization: Serialization,
     val tagIdResolver: TagIdResolver)(implicit val ec: ExecutionContext, val mat: Materializer)
     extends BaseByteArrayReadJournalDao {
+
+  import akka.persistence.postgres.db.ExtendedPostgresProfile.api._
 
   val queries = new ReadJournalQueries(
     PartitionedJournalTable(readJournalConfig.journalTableConfiguration),
@@ -31,4 +37,26 @@ class PartitionedReadJournalDao(
     new CachedTagIdResolver(
       new SimpleTagDao(db, readJournalConfig.tagsTableConfiguration),
       readJournalConfig.tagsConfig))
+
+  override def messages(
+      persistenceId: String,
+      fromSequenceNr: Long,
+      toSequenceNr: Long,
+      max: Long): Source[Try[(PersistentRepr, Long)], NotUsed] = {
+    // This behaviour override is only applied here, because it is only useful on the PartitionedJournal strategy.
+    val query = if (readJournalConfig.useJournalMetadata) {
+      metadataQueries.minAndMaxOrderingForPersistenceId(persistenceId).result.headOption.flatMap {
+        case Some((minOrdering, _)) =>
+          // if journal_metadata knows the min ordering of a persistenceId,
+          // use it to help the query planner to avoid scanning unnecessary partitions.
+          queries.messagesOrderingBoundedQuery(persistenceId, fromSequenceNr, toSequenceNr, max, minOrdering).result
+        case None =>
+          // fallback to standard behaviour
+          queries.messagesQuery(persistenceId, fromSequenceNr, toSequenceNr, max).result
+      }
+    } else
+      queries.messagesQuery(persistenceId, fromSequenceNr, toSequenceNr, max).result
+
+    Source.fromPublisher(db.stream(query)).via(serializer.deserializeFlow)
+  }
 }

--- a/core/src/main/scala/akka/persistence/postgres/query/dao/ReadJournalQueries.scala
+++ b/core/src/main/scala/akka/persistence/postgres/query/dao/ReadJournalQueries.scala
@@ -38,14 +38,12 @@ class ReadJournalQueries(journalTable: TableQuery[JournalTable], includeDeleted:
       fromSequenceNr: Rep[Long],
       toSequenceNr: Rep[Long],
       max: ConstColumn[Long],
-      minOrdering: Rep[Long],
-      maxOrdering: Rep[Long]): Query[JournalTable, JournalRow, Seq] =
+      minOrdering: Rep[Long]): Query[JournalTable, JournalRow, Seq] =
     baseTableQuery()
       .filter(_.persistenceId === persistenceId)
       .filter(_.sequenceNumber >= fromSequenceNr)
       .filter(_.sequenceNumber <= toSequenceNr)
       .filter(_.ordering >= minOrdering)
-      .filter(_.ordering <= maxOrdering)
       .sortBy(_.sequenceNumber.asc)
       .take(max)
 

--- a/core/src/main/scala/akka/persistence/postgres/query/dao/ReadJournalQueries.scala
+++ b/core/src/main/scala/akka/persistence/postgres/query/dao/ReadJournalQueries.scala
@@ -33,7 +33,7 @@ class ReadJournalQueries(journalTable: TableQuery[JournalTable], includeDeleted:
       .sortBy(_.sequenceNumber.asc)
       .take(max)
 
-  private def _messagesOrderingBoundedQuery(
+  private def _messagesMinOrderingBoundedQuery(
       persistenceId: Rep[String],
       fromSequenceNr: Rep[Long],
       toSequenceNr: Rep[Long],
@@ -49,7 +49,7 @@ class ReadJournalQueries(journalTable: TableQuery[JournalTable], includeDeleted:
 
   val messagesQuery = Compiled(_messagesQuery _)
 
-  val messagesOrderingBoundedQuery = Compiled(_messagesOrderingBoundedQuery _)
+  val messagesMinOrderingBoundedQuery = Compiled(_messagesMinOrderingBoundedQuery _)
 
   protected def _eventsByTag(
       tag: Rep[List[Int]],

--- a/core/src/test/scala/akka/persistence/postgres/journal/dao/JournalQueriesTest.scala
+++ b/core/src/test/scala/akka/persistence/postgres/journal/dao/JournalQueriesTest.scala
@@ -30,8 +30,7 @@ class JournalQueriesTest extends BaseQueryTest {
       11L,
       11L,
       11L,
-      11L,
-      11L) shouldBeSQL """select "ordering", "deleted", "persistence_id", "sequence_number", "message", "tags", "metadata" from "journal" where ((((("persistence_id" = ?) and ("deleted" = false)) and ("sequence_number" >= ?)) and ("sequence_number" <= ?)) and ("ordering" >= ?)) and ("ordering" <= ?) order by "sequence_number" limit ?"""
+      11L) shouldBeSQL """select "ordering", "deleted", "persistence_id", "sequence_number", "message", "tags", "metadata" from "journal" where (((("persistence_id" = ?) and ("deleted" = false)) and ("sequence_number" >= ?)) and ("sequence_number" <= ?)) and ("ordering" >= ?) order by "sequence_number" limit ?"""
   }
 
   it should "create SQL query for markJournalMessagesAsDeleted" in withJournalQueries { queries =>

--- a/core/src/test/scala/akka/persistence/postgres/journal/dao/JournalQueriesTest.scala
+++ b/core/src/test/scala/akka/persistence/postgres/journal/dao/JournalQueriesTest.scala
@@ -24,8 +24,8 @@ class JournalQueriesTest extends BaseQueryTest {
       11L) shouldBeSQL """select "ordering", "deleted", "persistence_id", "sequence_number", "message", "tags", "metadata" from "journal" where ((("persistence_id" = ?) and ("deleted" = false)) and ("sequence_number" >= ?)) and ("sequence_number" <= ?) order by "sequence_number" limit ?"""
   }
 
-  it should "create SQL query for messagesOrderingBoundedQuery" in withJournalQueries { queries =>
-    queries.messagesOrderingBoundedQuery(
+  it should "create SQL query for messagesMinOrderingBoundedQuery" in withJournalQueries { queries =>
+    queries.messagesMinOrderingBoundedQuery(
       "aaa",
       11L,
       11L,

--- a/core/src/test/scala/akka/persistence/postgres/query/dao/ReadJournalQueriesTest.scala
+++ b/core/src/test/scala/akka/persistence/postgres/query/dao/ReadJournalQueriesTest.scala
@@ -23,8 +23,7 @@ class ReadJournalQueriesTest extends BaseQueryTest {
       1L,
       4L,
       5L,
-      1L,
-      10L) shouldBeSQL """select "ordering", "deleted", "persistence_id", "sequence_number", "message", "tags", "metadata" from "journal" where (((("persistence_id" = ?) and ("sequence_number" >= ?)) and ("sequence_number" <= ?)) and ("ordering" >= ?)) and ("ordering" <= ?) order by "sequence_number" limit ?"""
+      1L) shouldBeSQL """select "ordering", "deleted", "persistence_id", "sequence_number", "message", "tags", "metadata" from "journal" where ((("persistence_id" = ?) and ("sequence_number" >= ?)) and ("sequence_number" <= ?)) and ("ordering" >= ?) order by "sequence_number" limit ?"""
   }
 
   it should "create SQL query for eventsByTag" in withReadJournalQueries { queries =>

--- a/core/src/test/scala/akka/persistence/postgres/query/dao/ReadJournalQueriesTest.scala
+++ b/core/src/test/scala/akka/persistence/postgres/query/dao/ReadJournalQueriesTest.scala
@@ -17,8 +17,8 @@ class ReadJournalQueriesTest extends BaseQueryTest {
       5L) shouldBeSQL """select "ordering", "deleted", "persistence_id", "sequence_number", "message", "tags", "metadata" from "journal" where (("persistence_id" = ?) and ("sequence_number" >= ?)) and ("sequence_number" <= ?) order by "sequence_number" limit ?"""
   }
 
-  it should "create SQL query for messagesOrderingBoundedQuery" in withReadJournalQueries { queries =>
-    queries.messagesOrderingBoundedQuery(
+  it should "create SQL query for messagesMinOrderingBoundedQuery" in withReadJournalQueries { queries =>
+    queries.messagesMinOrderingBoundedQuery(
       "aaa",
       1L,
       4L,


### PR DESCRIPTION
Query performance takes a hit if we use min and max_ordering values to do both sides of partition pruning. Keeping one of them keeps the same expected query plan.